### PR TITLE
sort config keys

### DIFF
--- a/fluent-bit/files/bit.conf.j2
+++ b/fluent-bit/files/bit.conf.j2
@@ -65,7 +65,7 @@
     {% macro plugin_config(plugins, type) -%}
     {%- for plugin in plugins %}
 [{{ type }}]
-      {%- for key, value in plugin.items() %}
+      {%- for key, value in sorted(plugin.items()) %}
     {{ key }} {{ value }}
       {%- endfor %}
     {%- endfor %}

--- a/fluent-bit/files/bit.conf.j2
+++ b/fluent-bit/files/bit.conf.j2
@@ -65,7 +65,7 @@
     {% macro plugin_config(plugins, type) -%}
     {%- for plugin in plugins %}
 [{{ type }}]
-      {%- for key, value in sorted(plugin.items()) %}
+      {%- for key, value in plugin | dictsort %}
     {{ key }} {{ value }}
       {%- endfor %}
     {%- endfor %}


### PR DESCRIPTION
Sorting config keys because the iteration order for a dictionary is not always the same which causes salt to report changes made in the file. Sorting the keys so that the config keys are always in the same order in the config file