### PR TITLE
manually_add_fluent_bit_key

### DIFF
--- a/fluent-bit/install.sls
+++ b/fluent-bit/install.sls
@@ -5,6 +5,10 @@
 
 {% set os_distrubition = grains['lsb_distrib_codename'] %}
 
+# Manually add the fluent-bit key as Salt does not update it
+add_fluent_bit_key:
+  cmd.run:
+    - name: "wget -qO - https://packages.fluentbit.io/fluentbit.key | sudo apt-key add -"
 
 fluent_pkgrepo:
   pkgrepo.managed:

--- a/fluent-bit/install.sls
+++ b/fluent-bit/install.sls
@@ -8,7 +8,7 @@
 # Manually add the fluent-bit key as Salt does not update it
 add_fluent_bit_key:
   cmd.run:
-    - name: "wget -qO - https://packages.fluentbit.io/fluentbit.key | sudo apt-key add -"
+    - name: "wget -qO - https://packages.fluentbit.io/fluentbit.key | apt-key add -"
 
 fluent_pkgrepo:
   pkgrepo.managed:


### PR DESCRIPTION
Manually add the fluent bit key. New fluent bit keys aren't added by Salt as nothing changes in the state definition. This adds a new state that manually adds the key before adding the ppa. 